### PR TITLE
moving tag icons to the right to not cover up dlc icons already on the left

### DIFF
--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -207,7 +207,7 @@ dim-store-item,
   filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.7));
   position: absolute;
   top: 4px;
-  left: 4px;
+  right: 4px;
   color: gold;
   pointer-events: none;
   &.no-tag {


### PR DESCRIPTION
#3245